### PR TITLE
Redirect pages belonging to repos that moved to googleapis

### DIFF
--- a/404.html
+++ b/404.html
@@ -88,31 +88,31 @@ permalink: /404.html
       </a>
     </div>
     <script>
+      // Redirects github pages for repos that have moved to another org.
       (function() {
 
         'use strict';
 
-        var movedRepos = [
-          'google-api-java-client',
-          'google-api-nodejs-client',
-          'google-api-python-client',
-          'google-auth-library-java',
-          'google-auth-library-nodejs',
-          'google-http-java-client',
-          'google-oauth-java-client',
-          'oauth2client'
-        ];
+        // Mapping from repo name to the org it moved to.
+        var movedRepos = {
+          'google-api-java-client':     'googleapis',
+          'google-api-nodejs-client':   'googleapis',
+          'google-api-python-client':   'googleapis',
+          'google-auth-library-java':   'googleapis',
+          'google-auth-library-nodejs': 'googleapis',
+          'google-http-java-client':    'googleapis',
+          'google-oauth-java-client':   'googleapis',
+          'oauth2client':               'googleapis'
+        };
 
-        var pathname = location.pathname;
-        if (location.host != 'googleapis.github.io') {
-          var found = movedRepos.find(function(repo) {
-            var regex = new RegExp('^/'+repo+'(/|$)');
-            return regex.test(pathname);
-          });
-          if (found) {
-            location.host = 'googleapis.github.io';
+        var repoRegex = new RegExp('^/([^/]+)(/|$)');
+        var match = repoRegex.exec(location.pathname);
+        if (match) {
+          var newOrg = movedRepos[match[1]];
+          if (newOrg) {
+            location.host = newOrg + '.github.io';
           }
-        } 
+        }
 
       }());
     </script>


### PR DESCRIPTION
Recently a number of repositories moved from the "google" org to the "googleapis" org. Some of those had associated gh-pages under the google.github.io domain. Now that these repos have moved, their pages can now be found under the googleapis.github.io domain. While many github URLs will redirect when a repo is moved, it looks like gh-pages do not redirect. As a result, existing links to those pages are currently broken.

This PR customizes the 404 page for google.github.io. (Currently, the toplevel index http://google.github.io/ is set up to redirect to https://github.com/google/ but any other pages with a nonempty path are not defined in this repository, and are yielding a default 404.) This custom 404 reproduces the default 404, but also includes a javascript redirect specifically for paths controlled by the moved repos. Any requests for pages associated with these repos will redirect to the new location under the googleapis.github.io domain. Any other pages will simply display a 404 page as they currently do.

(We are currently using a similar redirect for repos that have moved out of the GoogleCloudPlatform org.)