### PR TITLE
Redirect google.github.io/iree to openxla.github.io/iree

### DIFF
--- a/404.html
+++ b/404.html
@@ -102,7 +102,8 @@ permalink: /404.html
           'google-auth-library-nodejs': 'googleapis',
           'google-http-java-client':    'googleapis',
           'google-oauth-java-client':   'googleapis',
-          'oauth2client':               'googleapis'
+          'oauth2client':               'googleapis',
+          'iree':                       'openxla',
         };
 
         var repoRegex = new RegExp('^/([^/]+)(/|$)');


### PR DESCRIPTION
Part of moving IREE to the OpenXLA GitHub organization:
https://github.com/openxla/iree/issues/12102