### PR TITLE
Revert "Redirect google.github.io/iree to openxla.github.io/iree"

### DIFF
--- a/404.html
+++ b/404.html
@@ -102,8 +102,7 @@ permalink: /404.html
           'google-auth-library-nodejs': 'googleapis',
           'google-http-java-client':    'googleapis',
           'google-oauth-java-client':   'googleapis',
-          'oauth2client':               'googleapis',
-          'iree':                       'openxla',
+          'oauth2client':               'googleapis'
         };
 
         var repoRegex = new RegExp('^/([^/]+)(/|$)');


### PR DESCRIPTION
This reverts commit d6a75452e28f12247d0f0db8b144a6e59ac93681.

IREE moved GitHub organizations again:
* `google` -> `iree-org`
* `iree-org` -> `openxla`
* `openxla` -> `iree-org` (current)

We also use a custom domain (https://iree.dev/) instead of GitHub pages.

The current redirect (https://google.github.io/iree --> https://openxla.github.io/iree) is broken since we don't have a redirect from openxla to iree-org.

We can either redirect to `iree-org` (the current location) which automatically redirects again to our custom domain, or we can drop the old redirect entirely. This just drops the old redirect.