### PR TITLE
Update 404.html for A2A Repos

### DIFF
--- a/404.html
+++ b/404.html
@@ -103,8 +103,8 @@ permalink: /404.html
           'google-http-java-client':    'googleapis',
           'google-oauth-java-client':   'googleapis',
           'oauth2client':               'googleapis',
-          'a2a-python':                 'google-a2a',
-          'A2A':                        'google-a2a',
+          'a2a-python':                 'a2aproject',
+          'A2A':                        'a2aproject',
         };
 
         var repoRegex = new RegExp('^/([^/]+)(/|$)');


### PR DESCRIPTION
Current links are broken due to second repository move.